### PR TITLE
Add version to CLI

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use clap::Parser;
 
 #[derive(Parser)]
+#[command(version)]
 pub struct Cli {
     /// Postgresデータベースに接続する文字列。 ogr2ogr に渡されます。冒頭の `PG:` は省略してください。
     pub postgres_url: String,


### PR DESCRIPTION
Adding version to CLI so when I update my local install to latest release I can make sure I actually did replace the old version.