### PR TITLE
Fix bug preventing A29 from being mapped

### DIFF
--- a/src/loader/mapping.rs
+++ b/src/loader/mapping.rs
@@ -135,17 +135,25 @@ fn should_start_new_metadata_record(
         .and_then(|v| if v.is_empty() { None } else { Some(v) });
     let original_identifier = data_to_string(&row[8]);
     let mapping_id = data_to_string(&row[7]);
-    if let (Some(cat1), Some(cat2), Some(shapefile_names)) = (cat1, cat2, shapefile_names) {
+
+    if let (Some(cat1), Some(cat2)) = (cat1, cat2) {
         if builder.cat1.clone().is_some_and(|s| s != cat1)
             || builder.cat2.clone().is_some_and(|s| s != cat2)
-            || builder
-                .shapefile_matcher
-                .clone()
-                .is_some_and(|s| s != shapefile_names)
         {
             return true;
         }
     }
+
+    if let Some(shapefile_names) = shapefile_names {
+        if builder
+            .shapefile_matcher
+            .clone()
+            .is_some_and(|s| s != shapefile_names)
+        {
+            return true;
+        }
+    }
+
     if let (Some(identifier), Some(mapping_id)) = (original_identifier, mapping_id) {
         // 例外: 医療圏。１，２，３次医療圏はそれぞれ別テーブルとして扱う。
         // -> 識別子はそれぞれA38だが、属性コードの頭4文字が異なる（A38a, A38b, A38c）


### PR DESCRIPTION
Mapping A29 ([用途地域](https://nlftp.mlit.go.jp/ksj/gml/datalist/KsjTmplt-A29.html#!)) from the [xlsx file](https://nlftp.mlit.go.jp/ksj/gml/codelist/shape_property_table2.xlsx) fails because it has no value in the シェープファイル名 column.

The `should_start_new_metadata_record` function required a value in this field to return `true`. I allow this function to return `true` even when this column is empty.

<img width="1326" height="169" alt="Screenshot 2025-07-10 at 2 59 42 PM" src="https://github.com/user-attachments/assets/9297bb00-56df-4967-9a5f-f6bb99f2f098" />
