### PR TITLE
Add ability to choose data year

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,6 +27,11 @@ pub struct Cli {
     /// 複数指定する場合は `,` で区切ってください
     #[arg(long, value_delimiter = ',')]
     pub filter_identifiers: Option<Vec<String>>,
+
+    /// 取得するデータセットの年（例: 2019）
+    /// 指定しない場合は最新のデータセットが使用されます
+    #[arg(long)]
+    pub year: Option<u32>,
 }
 
 pub fn main() -> Cli {

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ async fn main() -> Result<()> {
     let scraper = scraper::ScraperBuilder::default()
         .skip_dl(args.skip_download)
         .filter_identifiers(args.filter_identifiers.clone())
+        .year(args.year)
         .build()
         .context("while building scraper")?;
     let datasets = scraper

--- a/src/scraper/mod.rs
+++ b/src/scraper/mod.rs
@@ -33,6 +33,7 @@ impl fmt::Display for Dataset {
 pub struct Scraper {
     skip_dl: bool,
     filter_identifiers: Option<Vec<String>>,
+    year: Option<u32>,
 }
 
 impl Scraper {
@@ -52,7 +53,7 @@ impl Scraper {
                 }
             }
 
-            let page_res = data_page::scrape(&initial_item.url).await;
+            let page_res = data_page::scrape(&initial_item.url, self.year).await;
             if let Err(err) = page_res {
                 println!("[ERROR, skipping...] {:?}", err);
                 continue;


### PR DESCRIPTION
Ran into an issue where A29 data is missing for Osaka city for the most recent dataset (2019) but is available for 2011. For my use cases - I would like to use the most recent data but "fill in the gaps" with older data where missing. For this I need to be able to download older datasets.

## 2019
<img width="1380" height="930" alt="Screenshot 2025-07-10 at 9 19 09 PM" src="https://github.com/user-attachments/assets/fa5c4d91-714e-45ea-924a-c84daf115c9d" />

## 2011
<img width="1386" height="959" alt="Screenshot 2025-07-10 at 9 20 58 PM" src="https://github.com/user-attachments/assets/11d88644-49de-4a98-b2b6-188d3c4aae9e" />


