### PR TITLE
Fix data table scraping

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,6 +27,11 @@ pub struct Cli {
     /// 複数指定する場合は `,` で区切ってください
     #[arg(long, value_delimiter = ',')]
     pub filter_identifiers: Option<Vec<String>>,
+
+    /// 取得するデータセットの年（例: 2019）
+    /// 指定しない場合は最新のデータセットが使用されます
+    #[arg(long)]
+    pub year: Option<u32>,
 }
 
 pub fn main() -> Cli {

--- a/src/loader/load_queue.rs
+++ b/src/loader/load_queue.rs
@@ -43,7 +43,7 @@ async fn load(
             shapefiles.extend(shapefiles_in_zip);
         }
 
-        // println!("Found {} shapefiles: {:?}", shapefiles.len(), shapefiles);
+        println!("Found {} shapefiles.", shapefiles.len());
 
         let has_layer = gdal::has_layer(postgres_url, &mapping.identifier).await?;
         if skip_if_exists && has_layer {

--- a/src/loader/mapping.rs
+++ b/src/loader/mapping.rs
@@ -135,17 +135,25 @@ fn should_start_new_metadata_record(
         .and_then(|v| if v.is_empty() { None } else { Some(v) });
     let original_identifier = data_to_string(&row[8]);
     let mapping_id = data_to_string(&row[7]);
-    if let (Some(cat1), Some(cat2), Some(shapefile_names)) = (cat1, cat2, shapefile_names) {
+
+    if let (Some(cat1), Some(cat2)) = (cat1, cat2) {
         if builder.cat1.clone().is_some_and(|s| s != cat1)
             || builder.cat2.clone().is_some_and(|s| s != cat2)
-            || builder
-                .shapefile_matcher
-                .clone()
-                .is_some_and(|s| s != shapefile_names)
         {
             return true;
         }
     }
+
+    if let Some(shapefile_names) = shapefile_names {
+        if builder
+            .shapefile_matcher
+            .clone()
+            .is_some_and(|s| s != shapefile_names)
+        {
+            return true;
+        }
+    }
+
     if let (Some(identifier), Some(mapping_id)) = (original_identifier, mapping_id) {
         // 例外: 医療圏。１，２，３次医療圏はそれぞれ別テーブルとして扱う。
         // -> 識別子はそれぞれA38だが、属性コードの頭4文字が異なる（A38a, A38b, A38c）

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ async fn main() -> Result<()> {
     let scraper = scraper::ScraperBuilder::default()
         .skip_dl(args.skip_download)
         .filter_identifiers(args.filter_identifiers.clone())
+        .year(args.year)
         .build()
         .context("while building scraper")?;
     let datasets = scraper

--- a/src/scraper/mod.rs
+++ b/src/scraper/mod.rs
@@ -33,6 +33,7 @@ impl fmt::Display for Dataset {
 pub struct Scraper {
     skip_dl: bool,
     filter_identifiers: Option<Vec<String>>,
+    year: Option<u32>,
 }
 
 impl Scraper {
@@ -52,7 +53,7 @@ impl Scraper {
                 }
             }
 
-            let page_res = data_page::scrape(&initial_item.url).await;
+            let page_res = data_page::scrape(&initial_item.url, self.year).await;
             if let Err(err) = page_res {
                 println!("[ERROR, skipping...] {:?}", err);
                 continue;


### PR DESCRIPTION
DRAFT: REQUIRES [17](https://github.com/KotobaMedia/jpksj-to-sql/pull/17) and [18](https://github.com/KotobaMedia/jpksj-to-sql/pull/18) to be merged first.

Scraping the downloads from the data table for [A33](https://nlftp.mlit.go.jp/ksj/gml/datalist/KsjTmplt-A33-2024.html) was broken due to an extra column (形式) being added. The existing code relied on column ordering being preserved and caused attempts to scrape A33 to break. 

This solution uses the column headers instead of column order to ensure scraping succeeds even when columns are out of order.